### PR TITLE
Support disabling API check via _bc_linter_enable

### DIFF
--- a/tools/stronghold/src/api/ast.py
+++ b/tools/stronghold/src/api/ast.py
@@ -19,20 +19,29 @@ def extract(path: pathlib.Path) -> Mapping[str, api.Parameters]:
      * ClassName.method_name
      * ClassName.SubClassName.method_name
     """
-    raw_api = extract_raw(path)
-    return {
-        name: _function_def_to_parameters(function_def)
-        for name, function_def in raw_api.items()
-    }
+    api_map, _ = extract_all(path)
+    return api_map
 
 
 def extract_raw(path: pathlib.Path) -> Mapping[str, ast.FunctionDef]:
-    """Extracts the API as ast.FunctionDef instances."""
+    """Extracts the API as ``ast.FunctionDef`` instances."""
+    _, raw = extract_all(path)
+    return raw
+
+
+def extract_all(
+    path: pathlib.Path,
+) -> tuple[Mapping[str, api.Parameters], Mapping[str, ast.FunctionDef]]:
+    """Extracts both parsed parameters and raw ``ast.FunctionDef`` nodes."""
     out: dict[str, ast.FunctionDef] = {}
     _ContextualNodeVisitor(out, context=[]).visit(
         ast.parse(path.read_text(), os.fspath(path))
     )
-    return out
+    api_map = {
+        name: _function_def_to_parameters(function_def)
+        for name, function_def in out.items()
+    }
+    return api_map, out
 
 
 def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:

--- a/tools/stronghold/src/api/compatibility.py
+++ b/tools/stronghold/src/api/compatibility.py
@@ -1,4 +1,11 @@
-"""Understands compatibility of APIs."""
+"""Understands compatibility of APIs.
+
+Functions or classes may opt-out of backward compatibility checks by
+setting ``_bc_linter_enable`` on the decorated object.  The helper
+``bc_linter.check_compat`` decorator does this automatically, but any
+custom decorator may use ``setattr(obj, "_bc_linter_enable", False)`` to
+disable linting.
+"""
 
 from __future__ import annotations
 
@@ -69,20 +76,17 @@ def check(
     before: pathlib.Path, after: pathlib.Path
 ) -> Sequence[api.violations.Violation]:
     """Identifies API compatibility issues between two files."""
-    before_api = api.ast.extract(before)
-    after_api = api.ast.extract(after)
-
-    before_raw = api.ast.extract_raw(before)
-    after_raw = api.ast.extract_raw(after)
+    before_api, before_raw = api.ast.extract_all(before)
+    after_api, after_raw = api.ast.extract_all(after)
 
     disabled_funcs = {
         name
         for name, node in before_raw.items()
-        if _decorator_disables(node)
+        if _decorator_disables(node, before_raw)
     } | {
         name
         for name, node in after_raw.items()
-        if _decorator_disables(node)
+        if _decorator_disables(node, after_raw)
     }
 
     violations: list[api.violations.Violation] = []
@@ -338,26 +342,52 @@ def _check_type_compatibility(
     return True
 
 
-def _decorator_disables(node: ast.FunctionDef) -> bool:
-    """Returns True if the bc_linter.check_compat decorator disables checks."""
+def _decorator_disables(node: ast.FunctionDef, raw: Mapping[str, ast.FunctionDef]) -> bool:
+    """Returns ``True`` if BC checks are disabled via decorators."""
 
     for deco in node.decorator_list:
         name = _decorator_name(deco)
-        if name != "bc_linter.check_compat":
-            continue
+        if name == "bc_linter.check_compat":
+            enable = True
+            if isinstance(deco, ast.Call):
+                # Look for keyword argument ``enable`` first
+                for kw in deco.keywords:
+                    if kw.arg == "enable" and isinstance(kw.value, ast.Constant):
+                        enable = bool(kw.value.value)
+                        break
+                else:
+                    if len(deco.args) == 1 and isinstance(deco.args[0], ast.Constant):
+                        enable = bool(deco.args[0].value)
 
-        enable = True
-        if isinstance(deco, ast.Call):
-            # Look for keyword argument ``enable`` first
-            for kw in deco.keywords:
-                if kw.arg == "enable" and isinstance(kw.value, ast.Constant):
-                    enable = bool(kw.value.value)
-                    break
-            else:
-                if len(deco.args) == 1 and isinstance(deco.args[0], ast.Constant):
-                    enable = bool(deco.args[0].value)
+            return not enable
 
-        return not enable
+        if name is not None:
+            decorator_node = raw.get(name)
+            if decorator_node is None:
+                continue
+            for stmt in ast.walk(decorator_node):
+                # Look for: setattr(obj, "_bc_linter_enable", <bool>)
+                if isinstance(stmt, ast.Call):
+                    if (
+                        isinstance(stmt.func, ast.Name)
+                        and stmt.func.id == "setattr"
+                        and len(stmt.args) >= 3
+                    ):
+                        attr_arg = stmt.args[1]
+                        value_arg = stmt.args[2]
+                        if (
+                            isinstance(attr_arg, ast.Constant)
+                            and attr_arg.value == "_bc_linter_enable"
+                            and isinstance(value_arg, ast.Constant)
+                        ):
+                            return not bool(value_arg.value)
+
+                # Look for: obj._bc_linter_enable = <bool>
+                if isinstance(stmt, ast.Assign):
+                    if isinstance(stmt.value, ast.Constant):
+                        for target in stmt.targets:
+                            if isinstance(target, ast.Attribute) and target.attr == "_bc_linter_enable":
+                                return not bool(stmt.value.value)
 
     return False
 

--- a/tools/stronghold/tests/api/test_compatibility.py
+++ b/tools/stronghold/tests/api/test_compatibility.py
@@ -537,3 +537,37 @@ def test_check_skip_decorator(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == []
+
+
+def test_check_skip_custom_decorator(tmp_path: pathlib.Path) -> None:
+    before = tmp_path / "before.py"
+    before.write_text(
+        textwrap.dedent(
+            """
+            def toggle(fn):
+                setattr(fn, "_bc_linter_enable", False)
+                return fn
+
+            @toggle
+            def func(x: int) -> None:
+                pass
+            """
+        )
+    )
+
+    after = tmp_path / "after.py"
+    after.write_text(
+        textwrap.dedent(
+            """
+            def toggle(fn):
+                setattr(fn, "_bc_linter_enable", False)
+                return fn
+
+            @toggle
+            def func(x: int, y: int) -> None:
+                pass
+            """
+        )
+    )
+
+    assert api.compatibility.check(before, after) == []


### PR DESCRIPTION
## Summary
- consolidate AST parsing in `api.ast` and expose `extract_all`
- allow custom decorators to disable compatibility checks by setting `_bc_linter_enable`
- document `_bc_linter_enable` handling
- add a test showing a custom decorator disabling the linter

## Testing
- `pytest tools/stronghold/tests/api/test_compatibility.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881644704888333bc63456a81cb68ea